### PR TITLE
v1.3.1 — CORS fix: activate L3 multi-user

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1696,9 +1696,13 @@
         // ===== L3 MULTI-USER AWARENESS (Azuracast nowplaying) =====
         // La creatura "sa" quanti la ascoltano in questo momento e lo lascia
         // trapelare nel rendering (pulse-per-listener, iris alpha, parallax
-        // density). Polling 45 s, server cache 15 s → impatto trascurabile.
-        // Fallback silenzioso su errore/CORS/offline → la creatura non si rompe.
-        const AZURACAST_URL = 'https://radio.freeundergroundtekno.org/api/nowplaying/free_underground_tekno';
+        // density). Polling 45 s, server cache 10 s + Cloudflare edge cache →
+        // impatto trascurabile.
+        // Endpoint statico: ha CORS aperto (Access-Control-Allow-Origin: *)
+        // configurato lato nginx Azuracast. Il dynamic /api/nowplaying/<station>
+        // invece blocca cross-origin. Stesso shape (listeners.current/unique/total).
+        // Fallback silenzioso su errore/offline → la creatura non si rompe.
+        const AZURACAST_URL = 'https://radio.freeundergroundtekno.org/api/nowplaying_static/free_underground_tekno.json';
         const LISTENER_POLL_MS = 45 * 1000;
         let liveListeners = 0;          // listeners.current (smoothed lerp consumer-side)
         let liveListenersUnique = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freetekno-youtube-streamer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Stream FreeTekno radio visualization to YouTube with independent audio/video capture",
   "main": "stream-to-youtube.js",
   "bin": "stream-to-youtube.js",


### PR DESCRIPTION
**Headline**: la community si accende — il fetch dei listener passa per l'endpoint statico, CORS-friendly, edge-cached.

In **v1.3.0** la L3 multi-user awareness era *in place ma dormiente*: il dynamic `/api/nowplaying/<station>` non emette `Access-Control-Allow-Origin`, e il fetch dal frontend (origin: listen.free-tekno.com) veniva bloccato dal browser → `azuracastOnline=false`, viz silenti (pulse-per-listener, iris boost, parallax density).

## Fix

- **Switch frontend a `/api/nowplaying_static/free_underground_tekno.json`**
  - CORS aperto già configurato lato nginx AzuraCast (no server change).
  - Servito via Cloudflare, `cache-control: max-age=10` → praticamente edge-cached, impatto sul radio origin trascurabile.
  - Stesso shape: `listeners.current / unique / total`, `is_online`.
- Polling cadence (45 s) e gating (skip su `document.hidden`) invariati.

## Si attiva

- **Pulse-per-listener** — ogni 4 bar BPM-locked, 1 micro-glow extra per listener oltre il primo (cap 12).
- **Iris alpha scale** — +25 % massimo con community attiva.
- **Constellation density** — starfield da 90 a 160 traits con +4 per listener.

---

made by fab23 <3 Free Tekno 4 ever
https://www.soundcloud.com/spaceinvaders
