### PR TITLE
privacy: /privacy notice + link + meta-CSP

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://radio.freeundergroundtekno.org; media-src 'self' https://radio.freeundergroundtekno.org; connect-src 'self' https://radio.freeundergroundtekno.org; font-src 'self'; base-uri 'self'; form-action 'self'">
     <title>FREE UNDERGROUND TEKNO - Live Radio VJ</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='%2300ff41' d='M2 1h1v1H2zM5 1h1v1H5zM10 1h1v1h-1zM13 1h1v1h-1zM3 2h1v1H3zM12 2h1v1h-1zM1 3h1v1H1zM4 3h2v1H4zM7 3h2v1H7zM10 3h2v1h-2zM14 3h1v1h-1zM1 4h1v1H1zM3 4h1v1H3zM5 4h6v1H5zM12 4h1v1h-1zM14 4h1v1h-1zM1 5h14v1H1zM1 6h1v1H1zM3 6h10v1H3zM14 6h1v1h-1zM1 7h1v1H1zM4 7h1v1H4zM11 7h1v1h-1zM14 7h1v1h-1zM2 8h2v1H2zM12 8h2v1h-2zM3 9h1v1H3zM5 9h1v1H5zM10 9h1v1h-1zM12 9h1v1h-1z'/%3E%3C/svg%3E">
     <style>
@@ -5001,5 +5002,6 @@
 
         console.log('FREE UNDERGROUND TEKNO - Radio VJ System Ready');
     </script>
+    <a href="/privacy.html" title="Privacy & legal — Publisher: Fabrizio Salmi (fabrizio.salmi@gmail.com)" style="position:fixed;bottom:6px;right:9px;z-index:99999;font-family:monospace;font-size:10px;color:#2f7a3a;text-decoration:none;opacity:.75;">privacy</a>
 </body>
 </html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; base-uri 'self'; form-action 'self'">
+    <meta name="robots" content="noindex, follow">
+    <title>Privacy &amp; Legal Notice — Free Underground Tekno</title>
+    <style>
+        :root { color-scheme: dark; --bg:#050805; --fg:#d8ffd8; --muted:#6f9a6f; --accent:#00ff41; --border:#123012; --code:#0c160c; }
+        *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;line-height:1.6;font-size:16px}
+        .wrap{max-width:760px;margin:0 auto;padding:2.5rem 1.25rem 4rem}
+        h1{font-size:1.8rem;margin:0 0 .25rem;color:#eafff0} h2{font-size:1.15rem;margin:2.25rem 0 .5rem;color:var(--accent);border-bottom:1px solid var(--border);padding-bottom:.3rem}
+        .lang-label{font-size:.7rem;text-transform:uppercase;letter-spacing:2px;color:var(--accent);margin:3rem 0 0}
+        .updated{color:var(--muted);font-size:.85rem;margin:0 0 1.5rem}
+        a{color:var(--accent)} code{background:var(--code);padding:.1rem .35rem;border-radius:3px;font-size:.85em}
+        ul{padding-left:1.25rem} li{margin:.35rem 0}
+        .home{display:inline-block;margin-bottom:2rem;color:var(--muted);text-decoration:none;font-size:.85rem}
+        hr{border:0;border-top:1px solid var(--border);margin:3rem 0 0} .muted{color:var(--muted);font-size:.85rem}
+    </style>
+</head>
+<body>
+<div class="wrap">
+    <a class="home" href="/">← listen.free-tekno.com</a>
+    <h1>Privacy &amp; Legal Notice</h1>
+    <p class="updated">Ultimo aggiornamento: 20 luglio 2026 · listen.free-tekno.com</p>
+
+    <p class="lang-label">Italiano</p>
+    <h2>Titolare del trattamento</h2>
+    <p><strong>Fabrizio Salmi</strong> — Genova, Italia. Progetto personale e non commerciale (radio/VJ della scena free tekno). Contatto: <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a>.</p>
+    <h2>Quali dati trattiamo e perché</h2>
+    <ul>
+        <li><strong>IP e dati basilari della richiesta</strong> trattati in modo transitorio dai fornitori di infrastruttura per erogare la pagina e proteggerla. Base giuridica: legittimo interesse (art. 6(1)(f) GDPR).</li>
+        <li><strong>Nessuna analitica</strong>, nessun pixel, nessuna pubblicità.</li>
+        <li><strong>Nessun account, modulo o newsletter.</strong></li>
+    </ul>
+    <h2>Streaming audio</h2>
+    <p>Quando avvii la radio, il flusso audio (e le informazioni "in onda") sono serviti dal nostro server di streaming <code>radio.freeundergroundtekno.org</code>: la riproduzione comporta che il tuo IP raggiunga quel server, per il solo scopo di erogarti l'audio. È infrastruttura del progetto, non un servizio pubblicitario o di tracciamento.</p>
+    <h2>Cookie e memoria del dispositivo</h2>
+    <p>Il sito <strong>non imposta cookie</strong> e <strong>non memorizza nulla</strong> sul dispositivo. Nessun banner di consenso richiesto.</p>
+    <h2>Responsabili e trasferimenti extra-UE</h2>
+    <ul>
+        <li><strong>GitHub, Inc.</strong> (USA) — hosting statico (GitHub Pages).</li>
+        <li><strong>Cloudflare, Inc.</strong> (USA) — CDN, HTTPS e sicurezza edge.</li>
+        <li><strong>radio.freeundergroundtekno.org</strong> — server di streaming del progetto (solo alla riproduzione).</li>
+    </ul>
+    <p>L'erogazione trasferisce dati tecnici (come l'IP) verso gli USA per l'hosting/CDN, coperti dagli accordi sul trattamento e dal Data Privacy Framework UE–USA / SCC.</p>
+    <h2>I tuoi diritti</h2>
+    <p>Accesso, rettifica, cancellazione, limitazione, opposizione, portabilità (artt. 15–22 GDPR) — <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a>. Reclamo al <a href="https://www.garanteprivacy.it" target="_blank" rel="noopener">Garante</a>. Nessuna profilazione.</p>
+
+    <p class="lang-label">English</p>
+    <h2>Data controller</h2>
+    <p><strong>Fabrizio Salmi</strong> — Genoa, Italy. Personal, non-commercial project (free-tekno scene radio/VJ). Contact: <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a>.</p>
+    <h2>What we process &amp; audio streaming</h2>
+    <p>Your IP and basic request data are processed transiently by our host to deliver the page (legitimate interest). <strong>No analytics, no accounts, no forms.</strong> When you start the radio, the audio stream and now-playing data are served by our streaming server <code>radio.freeundergroundtekno.org</code>, so playback sends your IP to that server for the sole purpose of delivering the audio — project infrastructure, not a tracker.</p>
+    <h2>Cookies, processors &amp; rights</h2>
+    <p>No cookies, no device storage. Processors: GitHub, Inc. (USA) hosting, Cloudflare, Inc. (USA) CDN, and our own streaming server (on playback). Transfers to the USA are covered by DPAs and the EU–US Data Privacy Framework / SCCs. You have the rights in Arts. 15–22 GDPR — email <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a> — and may complain to the <a href="https://www.garanteprivacy.it" target="_blank" rel="noopener">Garante</a>. No profiling.</p>
+
+    <hr>
+    <p class="muted">Publisher / Titolare: Fabrizio Salmi — Genoa, Italy — <a href="mailto:fabrizio.salmi@gmail.com">fabrizio.salmi@gmail.com</a></p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds the privacy/legal layer to listen.free-tekno.com (free-tekno radio/VJ page).

- **docs/privacy.html** (new): IT/EN notice — controller *Fabrizio Salmi*, host *GitHub + Cloudflare (US)*, discloses the audio stream server `radio.freeundergroundtekno.org` (project infra, your IP reaches it only on playback), no cookies/storage, rights + Garante.
- **docs/index.html**: subtle fixed `privacy` link (immersive full-screen page) · meta-CSP scoped to allow the radio stream.

Verified locally: VJ visual renders, **no CSP console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)