### PR TITLE
Add null/undefined safety for audioData.metrics and beat

### DIFF
--- a/docs/rave-framework/components/StrobeComponent.js
+++ b/docs/rave-framework/components/StrobeComponent.js
@@ -53,14 +53,14 @@ class StrobeComponent extends BaseComponent {
         
         if (!audioData || !this.enabled) return;
         
-        // Get metric value
+        // Safely extract metric value
         let value = 0;
         if (this.metric === 'punch') {
-            value = audioData.metrics.punch || 0;
+            value = (audioData.metrics && audioData.metrics.punch != null) ? audioData.metrics.punch : 0;
         } else if (this.metric === 'peak') {
-            value = audioData.metrics.peak || 0;
-        } else if (this.metric === 'kick' && audioData.beat) {
-            value = audioData.beat.kick ? 1 : 0;
+            value = (audioData.metrics && audioData.metrics.peak != null) ? audioData.metrics.peak : 0;
+        } else if (this.metric === 'kick') {
+            value = (audioData.beat && audioData.beat.kick) ? 1 : 0;
         }
         
         // Trigger strobe if above threshold


### PR DESCRIPTION
### FabGPT — code quality

**File:** `docs/rave-framework/components/StrobeComponent.js`

**Rationale:** The update() method directly accesses audioData.metrics.punch, audioData.metrics.peak, and audioData.beat.kick without verifying that audioData, metrics, or beat exist — this can cause runtime errors if audioData is incomplete or malformed, which is common during initialization or with faulty input streams.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `35db57316810704b` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"35db57316810704b","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":12.77,"prompt_sha":"ede7a9cfcbd001c0","triage":"INFO"} -->