### PR TITLE
Fix undefined `drawWaveform`/`drawGrid` calls when canvas is missing

### DIFF
--- a/docs/radio/js/visualizers/strobo.js
+++ b/docs/radio/js/visualizers/strobo.js
@@ -20,6 +20,8 @@ const Strobo = (function() {
     }
 
     function draw(canvas, ctx, dataArray, analyser) {
+        if (!ctx) return;
+
         // Calcola intensità
         const bassSum = dataArray.slice(0, 50).reduce((a, b) => a + b, 0);
         const midSum = dataArray.slice(50, 150).reduce((a, b) => a + b, 0);


### PR DESCRIPTION
### FabGPT — code quality

**File:** `docs/radio/js/visualizers/strobo.js`

**Rationale:** The `draw` function unconditionally calls `drawWaveform` and `drawGrid`, but these functions use `ctx` (the 2D context) without verifying it exists. If `canvas` is null/undefined or fails to provide a context (e.g., offscreen canvas not supported, or misconfigured), `ctx` could be undefined, causing a runtime error when calling `ctx.fillStyle`, `ctx.beginPath`, etc. This is triggered in real usage when the visualizer runs on an invalid or hidden canvas.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `fb5f24e4310e4634` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"fb5f24e4310e4634","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":9.22,"prompt_sha":"6f14d62ea9149d03","triage":"INFO"} -->