### PR TITLE
Fix command injection in curl call

### DIFF
--- a/stream-to-youtube.js
+++ b/stream-to-youtube.js
@@ -78,14 +78,25 @@ class YouTubeStreamer {
 
   async checkPageReachable() {
     this.log('INFO', `Checking page: ${this.pageUrl}`);
-    try {
-      execSync(`curl -s --max-time 10 "${this.pageUrl}" > /dev/null`, { stdio: 'pipe' });
-      this.log('SUCCESS', '✓ Page is reachable');
-      return true;
-    } catch {
-      this.log('ERROR', `Cannot reach ${this.pageUrl}`);
-      return false;
-    }
+    return new Promise((resolve) => {
+      const curl = spawn('curl', ['-s', '--max-time', '10', this.pageUrl, '-o', '/dev/null']);
+      let hasError = false;
+
+      curl.on('close', (code) => {
+        if (code === 0) {
+          this.log('SUCCESS', '✓ Page is reachable');
+          resolve(true);
+        } else {
+          this.log('ERROR', `Cannot reach ${this.pageUrl}`);
+          resolve(false);
+        }
+      });
+
+      curl.on('error', () => {
+        this.log('ERROR', `Cannot reach ${this.pageUrl}`);
+        resolve(false);
+      });
+    });
   }
 
   async launchBrowser() {


### PR DESCRIPTION
### FabGPT — security

**File:** `stream-to-youtube.js` (line 82)
**Class:** command injection — detected: template-literal interpolation into exec()

**Rationale:** The tainted value `this.pageUrl` comes from user-provided CLI arguments (`-u` or `--url`) and is directly interpolated into a shell command string via template literal, enabling command injection. The fix replaces the vulnerable `execSync` shell invocation with a parameterized array of arguments passed to `spawn`, eliminating shell interpretation and neutralizing the injection vector at the sink.

_Static-detected, LLM-fixed; reviewed by a human before opening._

---
🤖 **FabGPT OS** · source `security` · model `qwen3-coder-next` · task `bc4806dbf0b33f80` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"bc4806dbf0b33f80","source":"security","model":"qwen3-coder-next","severity":"WARN","iterations":1,"inference_s":19.83,"triage":"WARN"} -->